### PR TITLE
avoid two regions iterations calling currentRegions.set in both loops.

### DIFF
--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -37,9 +37,7 @@ FlowLayout._regionsToData = function _regionsToData(regions, data) {
   data = data || {};
   _.each(regions, function(value, key) {
     currentRegions.set(key, value);
-    data[key] = function() {
-      return currentRegions.get(key);
-    };
+    data[key] = FlowLayout._buildRegionGetter(key);
   });
 
   return data;
@@ -48,17 +46,16 @@ FlowLayout._regionsToData = function _regionsToData(regions, data) {
 FlowLayout._updateRegions = function _updateRegions(regions) {
   var needsRerender = false;
   _.each(regions, function(value, key) {
-    // if this key does not exists earlier blaze
+    // if this key does not yet exist then blaze
     // has no idea about this key and it won't get the value of this key
-    // so, we need to do force re-render
+    // so, we need to force a re-render
     if(currentData && currentData[key] === undefined) {
       needsRerender = true;
+      // and, add the data function for this new key
+      currentData[key] = FlowLayout._buildRegionGetter(key);
     }
     currentRegions.set(key, value);
   });
-
-  // we need to update the currentData with new values
-  FlowLayout._regionsToData(regions, currentData);
 
   // force re-render if we need to
   if(currentLayout && needsRerender) {
@@ -68,4 +65,10 @@ FlowLayout._updateRegions = function _updateRegions(regions) {
 
 FlowLayout._getRootDomNode = function _getRootDomNode() {
   return $('#__flow-root').get(0);
+};
+
+FlowLayout._buildRegionGetter = function _buildRegionGetter(key) {
+  return function() {
+    return currentRegions.get(key);
+  };
 };


### PR DESCRIPTION
1. Moved getter function generation to its own internal API function.
2. used new generator in `_regionsToData`, replacing its original use
3. used new generator in `_updateRegions` when a new key is encountered
4. removed call to `_regionsToData` in `_updateRegions` because above changes made it unnecessary

Previously, the code would make an `_.each(regions...)` call in `_updateRegions` and then again when it calls `regionsToData`. This did the same iteration *twice*. And, both iterations called `currentRegions.set(key,value);`

The `_updateRegions` function needed to generate new getters for new keys, which `_regionsToData` would do for it. It would also recreate generators for existing keys; which is unnecessary.

This implementation:

1. iterates over regions only once
2. generates new getter only when a generator is missing
3. calls `currentRegions.set(key,value)` only once per key/value pair 