### PR TITLE
use a template for the root node

### DIFF
--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -1,6 +1,7 @@
-var currentLayoutName = null;
+var currentLayoutName = new ReactiveVar();
 var currentLayout = null;
 var currentRegions = new ReactiveDict();
+var initializedWrapper = false;
 var currentData;
 
 FlowLayout.setRoot = function(root) {
@@ -10,29 +11,36 @@ FlowLayout.setRoot = function(root) {
 FlowLayout.render = function render(layout, regions) {
   Meteor.startup(function() {
     var rootDomNode = FlowLayout._getRootDomNode();
-    if(currentLayoutName != layout) {
+    if(currentLayoutName.get() != layout) {
       // remove old view
       FlowLayout.reset();
+      // set data for layout
       currentData = FlowLayout._regionsToData(regions);
+      // dont use blaze.render here -> do it in the layout
 
-      currentLayout = Blaze._TemplateWith(currentData, function() {
-        return Spacebars.include(Template[layout]);
-      });
-
-      Blaze.render(currentLayout, rootDomNode);
-      currentLayoutName = layout;
+      // set layout name reactivly
+      currentLayoutName.set(layout);
     } else {
       FlowLayout._updateRegions(regions);
     }
   });
 };
 
+// helpers for the root layout
+Template.flowLayoutRoot.helpers({
+  layout: function(){
+    return currentLayoutName.get();
+  },
+  currentData: function() {
+    return currentData;
+  }
+});
+
 FlowLayout.reset = function reset() {
   var rootDomNode = FlowLayout._getRootDomNode();
   if(currentLayout) {
-    Blaze.remove(currentLayout);
     currentLayout = null;
-    currentLayoutName = null;
+    currentLayoutName = new ReactiveVar();
     currentRegions = new ReactiveDict();
   }
 };
@@ -68,14 +76,23 @@ FlowLayout._updateRegions = function _updateRegions(regions) {
 };
 
 FlowLayout._getRootDomNode = function _getRootDomNode() {
-  var root = FlowLayout._root
+  var root = FlowLayout._root;
+
+  if(!initializedWrapper){
+    // only render the container once
+    Blaze.render(Template.flowLayoutRoot, $('body').get(0));
+    initializedWrapper = true;
+  }
   if(!root) {
-    root = $('<div id="__flow-root"></div>');
-    $('body').append(root);
+    // use standard flow-router root node
+    root = $('#__flow-root');
+    FlowLayout.setRoot(root);
+  }else{
+    // use custom root node
+    root = $(root);
     FlowLayout.setRoot(root);
   }
-
-  // We need to use $(root) here because when calling FlowLayout.setRoot(), 
+  // We need to use $(root) here because when calling FlowLayout.setRoot(),
   // there won't have any available DOM elements
   // So, we need to defer that.
   var domNode = $(root).get(0);

--- a/lib/client/root.html
+++ b/lib/client/root.html
@@ -1,0 +1,5 @@
+<template name="flowLayoutRoot">
+  <div id="__flow-root">
+    {{> Template.dynamic template=layout data=currentData}}
+  </div>
+</template>

--- a/package.js
+++ b/package.js
@@ -24,8 +24,10 @@ function configure(api) {
   api.use('blaze');
   api.use('templating');
   api.use('reactive-dict');
+  api.use('reactive-var');
   api.use('underscore');
 
   api.addFiles('lib/client/namespace.js', 'client');
+  api.addFiles('lib/client/root.html', 'client');
   api.addFiles('lib/client/layout.js', 'client');
 }


### PR DESCRIPTION
developers are able to replace the standard root template with their own template (via aldeed:template-extension), which adds support for transitions of the whole layout. This is used by the momentum-flow-router package to enable developers to get fullpage transitions - which are crucial on mobile - working easily.